### PR TITLE
Add Orders Display with ViewModel and Firestore Real-Time Updates

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -89,4 +89,5 @@ dependencies {
     // Firebase auth
     implementation("com.google.firebase:firebase-auth")
 
+    implementation ("androidx.compose.runtime:runtime-livedata:1.7.8")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
 
     <application
         android:name=".Application"

--- a/app/src/main/java/com/dining/totable/MainActivity.kt
+++ b/app/src/main/java/com/dining/totable/MainActivity.kt
@@ -16,6 +16,7 @@ import com.dining.totable.ui.theme.ToTableTheme
 import com.dining.totable.utils.PermissionHelper
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
+import com.google.firebase.messaging.FirebaseMessaging
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -36,6 +37,15 @@ class MainActivity : ComponentActivity() {
                         }
                     )
                     AppNavigator()
+                    val restaurantId = "zWiTgflfIQbYmS8Y9hHw" // restaurant ID from Firestore
+                    FirebaseMessaging.getInstance().subscribeToTopic("restaurant_$restaurantId")
+                        .addOnCompleteListener { task ->
+                            if (task.isSuccessful) {
+                                Log.d("FCM", "Subscribed to topic: restaurant_$restaurantId")
+                            } else {
+                                Log.e("FCM", "Subscription failed", task.exception)
+                            }
+                        }
                     val db = Firebase.firestore
                     val docRef = db.collection("restaurants").document("1")
                     docRef.get()

--- a/app/src/main/java/com/dining/totable/services/MyFirebaseMessagingService.kt
+++ b/app/src/main/java/com/dining/totable/services/MyFirebaseMessagingService.kt
@@ -1,45 +1,36 @@
 package com.dining.totable.services
 
+import android.app.NotificationManager
+import android.content.Context
 import android.content.Intent
 import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import com.dining.totable.R
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
-import java.lang.Exception
 
 class MyFirebaseMessagingService : FirebaseMessagingService() {
+
     override fun onNewToken(token: String) {
         super.onNewToken(token)
     }
 
-    override fun onSendError(msgId: String, exception: Exception) {
-        super.onSendError(msgId, exception)
-    }
-
-    override fun onMessageSent(msgId: String) {
-        super.onMessageSent(msgId)
-    }
-
-    override fun onDeletedMessages() {
-        super.onDeletedMessages()
-    }
-
     override fun onMessageReceived(remoteMessage: RemoteMessage) {
-        // TODO(developer): Handle FCM messages here.
-        // Not getting messages here? See why this may be: https://goo.gl/39bRNJ
-        Log.d(TAG, "From: ${remoteMessage.from}")
+        super.onMessageReceived(remoteMessage)
+        Log.d(TAG, "Message received from: ${remoteMessage.from}")
 
-        // Check if message contains a data payload.
+        remoteMessage.notification?.let {
+            val title = it.title ?: "New Order"
+            val body = it.body ?: "A new order has been received"
+            Log.d(TAG, "Notification: $title - $body")
+            sendNotification(title, body)
+        }
+
+        // Handle data payload (if any)
         if (remoteMessage.data.isNotEmpty()) {
-            Log.d(TAG, "Message data payload: ${remoteMessage.data}")
-
-            // Check if data needs to be processed by long running job
-//            if (needsToBeScheduled()) {
-//                // For long-running tasks (10 seconds or more) use WorkManager.
-//                scheduleJob()
-//            } else {
-//                // Handle message within 10 seconds
-//                handleNow()
-//            }
+            Log.d(TAG, "Data payload: ${remoteMessage.data}")
+            // I can use this to pass additional order details if needed
         }
 
         // Check if message contains a notification payload.
@@ -51,6 +42,26 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
         // message, here is where that should be initiated. See sendNotification method below.
     }
 
+    private fun sendNotification(title: String, body: String) {
+        val notificationManager =
+            getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val notification = NotificationCompat.Builder(
+            this,
+            ContextCompat.getString(this, R.string.default_notification_channel_id)
+        )
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle(title)
+            .setContentText(body)
+            .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+            .setAutoCancel(true)
+            .build()
+
+        notificationManager.notify(
+            1,
+            notification
+        )
+    }
+
     override fun handleIntent(intent: Intent?) {
         super.handleIntent(intent)
     }
@@ -60,7 +71,6 @@ class MyFirebaseMessagingService : FirebaseMessagingService() {
     }
 
     companion object {
-
         private const val TAG = "MyFirebaseMsgService"
     }
 }

--- a/app/src/main/java/com/dining/totable/ui/composables/OrderItem.kt
+++ b/app/src/main/java/com/dining/totable/ui/composables/OrderItem.kt
@@ -21,7 +21,7 @@ import com.dining.totable.ui.utils.SpecialRequests
 @Composable
 fun OrderItem(
     itemName: String,
-    specialRequests: Map<Int, String>,
+    specialRequests: Map<String, String>,
     price: Double? = null,
     hasTellMe: Boolean? = false
 ) {
@@ -98,18 +98,18 @@ private fun OrderItemSpecialRequestCard(
 
 
 @Composable
-private fun OrderItemSpecialRequests(specialRequests: Map<Int, String>) {
+private fun OrderItemSpecialRequests(specialRequests: Map<String, String>) {
     specialRequests.forEach {
         OrderItemSpecialRequestCard(
             containerColor = when (it.key) {
-                0 -> Color.Red
-                1 -> Color.Green
-                2 -> Color.Yellow
+                "0" -> Color.Red
+                "1" -> Color.Green
+                "2" -> Color.Yellow
                 else -> Color.Gray
             }
         ) {
-            val specialRequest = "${SpecialRequests.specialRequestsMap[it.key] ?: ""} ${it.value}"
-            val specialRequestColor = if (it.key == 0) Color.White else Color.Unspecified
+            val specialRequest = "${SpecialRequests.specialRequestsMap[it.key.toInt()] ?: ""} ${it.value}"
+            val specialRequestColor = if (it.key.toInt() == 0) Color.White else Color.Unspecified
             SpecialRequestText(specialRequest, specialRequestColor)
         }
     }
@@ -136,9 +136,9 @@ fun OrderItemPreview() {
     OrderItem(
         itemName = "Cheeseburger",
         specialRequests = mapOf(
-            0 to "Pickles",
-            2 to "Lettuce",
-            1 to "Tomato"
+            "0" to "Pickles",
+            "2" to "Lettuce",
+            "1" to "Tomato"
         ),
         hasTellMe = true,
         price = 8.99

--- a/app/src/main/java/com/dining/totable/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/dining/totable/ui/screens/MainScreen.kt
@@ -3,22 +3,30 @@ package com.dining.totable.ui.screens
 import android.content.pm.ActivityInfo
 import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.dining.totable.ui.composables.MainScreenTopBar
+import com.dining.totable.ui.composables.OrderItem
 import com.dining.totable.ui.utils.TopBarOption
 import com.dining.totable.utils.DeviceConfigManager
-import com.google.firebase.auth.ktx.auth
-import com.google.firebase.ktx.Firebase
+import com.dining.totable.viewmodels.OrdersViewModel
 
 @Composable
 fun MainScreen(navController: NavController) {
     val activity = LocalActivity.current
     val context = LocalContext.current
+    val viewModel: OrdersViewModel = viewModel()
+    val orders by viewModel.orders.observeAsState()
     DisposableEffect(Unit) {
         // Force landscape when entering the screen
         activity!!.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
@@ -26,6 +34,9 @@ fun MainScreen(navController: NavController) {
             // Reset to system default when leaving the screen
             activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
         }
+    }
+    LaunchedEffect(Unit) {
+        viewModel.fetchOrders("zWiTgflfIQbYmS8Y9hHw")
     }
     Scaffold(modifier = Modifier.fillMaxSize(), topBar = {
         MainScreenTopBar(navController = navController,
@@ -38,6 +49,17 @@ fun MainScreen(navController: NavController) {
             }
         )
     }) { paddingValues ->
-        val todo = paddingValues
+        LazyColumn(modifier = Modifier.fillMaxSize(),
+            contentPadding = paddingValues) {
+            if(orders != null) {
+                items(orders!!) {
+                    OrderItem(
+                        itemName = it.itemName,
+                        specialRequests = it.specialRequests,
+                        price = it.price
+                    )
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/dining/totable/viewmodels/OrdersViewModel.kt
+++ b/app/src/main/java/com/dining/totable/viewmodels/OrdersViewModel.kt
@@ -1,0 +1,65 @@
+package com.dining.totable.viewmodels
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+import com.google.firebase.firestore.ListenerRegistration
+
+data class Order(
+    val id: String = "",
+    val itemName: String = "",
+    val specialRequests: Map<String, String>,
+    val price: Double = 0.0,
+    val status: String = "pending"
+)
+
+class OrdersViewModel : ViewModel() {
+    private val db = Firebase.firestore
+    private val _orders = MutableLiveData<List<Order>>()
+    val orders: LiveData<List<Order>> = _orders
+    private var listenerRegistration: ListenerRegistration? = null
+
+    fun fetchOrders(restaurantId: String) {
+        listenerRegistration = db.collection("restaurants")
+            .document(restaurantId)
+            .collection("orders")
+            .orderBy("timestamp", com.google.firebase.firestore.Query.Direction.DESCENDING)
+            .addSnapshotListener { snapshot, error ->
+                if (error != null) {
+                    // Handle error (e.g., log it or update UI)
+                    return@addSnapshotListener
+                }
+                val orderList = snapshot?.documents?.map { doc ->
+                    Order(
+                        id = doc.id,
+                        itemName = doc.getString("itemName") ?: "",
+                        specialRequests = doc.get("specialRequests") as? Map<String, String> ?: emptyMap(),
+                        price = doc.getDouble("price") ?: 0.0,
+                        status = doc.getString("status") ?: "pending"
+                    )
+                } ?: emptyList()
+                _orders.value = orderList
+            }
+    }
+
+    fun updateOrderStatus(restaurantId: String, orderId: String, newStatus: String) {
+        db.collection("restaurants")
+            .document(restaurantId)
+            .collection("orders")
+            .document(orderId)
+            .update("status", newStatus)
+            .addOnSuccessListener {
+
+            }
+            .addOnFailureListener { e ->
+
+            }
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        listenerRegistration?.remove()
+    }
+}


### PR DESCRIPTION
This PR enhances the Android app to fetch and display orders directly from Firestore’s `restaurants/{restaurantId}/orders` collection using a `ViewModel`. It includes UI updates for dynamic order rendering.

## Changes
- **ViewModel**: Added `OrdersViewModel.kt`:
  - Implemented `fetchOrders` with Firestore snapshot listener for real-time updates on a specific `restaurantId`.
  - Added `updateOrderStatus` for future status changes (not yet used).
- **UI**: Updated `MainScreen.kt`:
  - Integrated `OrdersViewModel` to observe and render orders in a `LazyColumn`.
  - Initiated order fetch with `LaunchedEffect` for restaurant ID `zWiTgflfIQbYmS8Y9hHw`. (Hardcoded for now)
- **Manifest**: Modified `AndroidManifest.xml`:
  - Configured Firebase messaging with default icon, color, and notification channel.
- **Dependencies**: Added `androidx.compose.runtime:runtime-livedata:1.7.8` to `build.gradle` for LiveData-Compose integration.
- **Messaging**: Updated `MyFirebaseMessagingService.kt` to handle and display FCM notifications for new orders.

## Testing
- Tested locally with sample orders in Firestore:
  - Orders render correctly in `LazyColumn` with real-time updates.
  - New orders trigger UI refresh instantly.
  - Notifications display with correct title and body via FCM.

## Next Steps
- Add UI controls to update order status (e.g., mark as "served").
- Implement logout and settings options in `MainScreenTopBar`.
- Replace hardcoded `restaurantId` with dynamic configuration.

Closes #9