### PR TITLE
Removal of Restaurant ID Input Logic

### DIFF
--- a/app/src/main/java/com/dining/totable/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/dining/totable/ui/screens/LoginScreen.kt
@@ -28,12 +28,11 @@ import com.dining.totable.ui.composables.textfields.ToTableTextField
 import com.dining.totable.utils.DeviceConfigManager
 import com.dining.totable.utils.DeviceConfiguration
 import com.dining.totable.utils.DeviceRole
-import com.dining.totable.utils.RestaurantIdToValidEmailConverter.toValidFirebaseAuthEmail
 import com.google.firebase.auth.FirebaseAuth
 
 @Composable
 fun LoginScreen(navController: NavController) {
-    var restaurantId by remember { mutableStateOf("") }
+    var restaurantEmail by remember { mutableStateOf("") }
     var restaurantPassword by remember { mutableStateOf("") }
     var role: DeviceRole? by remember { mutableStateOf(null) }
     Column(
@@ -42,9 +41,9 @@ fun LoginScreen(navController: NavController) {
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         ToTableTextField(
-            value = restaurantId,
-            onValueChange = { restaurantId = it },
-            label = { Text(stringResource(R.string.restaurant_id)) },
+            value = restaurantEmail,
+            onValueChange = { restaurantEmail = it },
+            label = { Text(stringResource(R.string.restaurant_email)) },
             leadingIcon = {
                 Icon(
                     painter = painterResource(id = R.drawable.storefront_24px),
@@ -76,7 +75,7 @@ fun LoginScreen(navController: NavController) {
         ToTableButton(stringResource(R.string.login)) {
             if (role != null) { // ensure they select a role before attempting login
                 login(
-                    restaurantId = restaurantId,
+                    restaurantEmail = restaurantEmail,
                     restaurantPassword = restaurantPassword,
                     onLoginAttemptFailed = {
                         Log.w(TAG, "$it ?: ${context.getString(R.string.login_failed)}")
@@ -90,7 +89,7 @@ fun LoginScreen(navController: NavController) {
                         DeviceConfigManager(context).saveConfiguration(
                             DeviceConfiguration(
                                 deviceRole = role!!, // save the role so device starts in correct role next time
-                                restaurantId = restaurantId
+                                restaurantId = restaurantEmail
                             )
                         )
                         navController.navigate("home")
@@ -108,13 +107,13 @@ fun LoginScreen(navController: NavController) {
 }
 
 private fun login(
-    restaurantId: String,
+    restaurantEmail: String,
     restaurantPassword: String,
     onLoginAttemptFailed: (String?) -> Unit,
     onLoginAttemptSuccess: () -> Unit
 ) {
     FirebaseAuth.getInstance()
-        .signInWithEmailAndPassword(restaurantId.toValidFirebaseAuthEmail(), restaurantPassword)
+        .signInWithEmailAndPassword(restaurantEmail, restaurantPassword)
         .addOnCompleteListener { task ->
             if (task.isSuccessful) {
                 onLoginAttemptSuccess()

--- a/app/src/main/java/com/dining/totable/utils/RestaurantIdToValidEmailConverter.kt
+++ b/app/src/main/java/com/dining/totable/utils/RestaurantIdToValidEmailConverter.kt
@@ -1,5 +1,0 @@
-package com.dining.totable.utils
-
-object RestaurantIdToValidEmailConverter {
-    fun String.toValidFirebaseAuthEmail() = "$this@totable.com"
-}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,7 +2,7 @@
     <string name="app_name">To Table</string>
     <string name="default_notification_channel_id" translatable="false">fcm_default_channel_id</string>
     <string name="default_notification_channel_name">Order Notifications</string>
-    <string name="restaurant_id">Restaurant ID</string>
+    <string name="restaurant_email">Restaurant Email</string>
     <string name="password">Password</string>
     <string name="login">Login</string>
     <string name="login_failed">Login has failed please try again</string>


### PR DESCRIPTION
### Summary
This PR removes the logic that allowed users to enter a restaurant ID for authentication. The feature was deemed infeasible due to the following reasons:
- **Auto-generated IDs**: Restaurant IDs are long, auto-generated strings that are difficult for users to remember or input accurately.
- **Web app authentication**: Staff on the web app sign up and authenticate using their email addresses, not restaurant IDs, making the ID-based input incompatible with the existing authentication flow.

### Changes Made
- Changed the restaurant ID input field on the login page to a restaurant email field and associated logic from the authentication process.
- Ensured no impact on the existing email-based authentication for web app staff.