### PR TITLE
Dynamically Fetch Restaurant ID by Email in LoginScreen

### DIFF
--- a/app/src/main/java/com/dining/totable/navigation/AppNavigator.kt
+++ b/app/src/main/java/com/dining/totable/navigation/AppNavigator.kt
@@ -1,22 +1,25 @@
 package com.dining.totable.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.dining.totable.ui.screens.MainScreen
 import com.dining.totable.ui.screens.LoginScreen
+import com.dining.totable.viewmodels.ToTableViewModel
 import com.google.firebase.auth.FirebaseAuth
 
 @Composable
 fun AppNavigator() {
     val navController = rememberNavController()
     val auth = FirebaseAuth.getInstance()
+    val viewModel: ToTableViewModel = viewModel()
     NavHost(
         navController = navController,
         startDestination = if (auth.currentUser != null) "home" else "login"
     ) {
-        composable("login") { LoginScreen(navController) }
-        composable("home") { MainScreen(navController) }
+        composable("login") { LoginScreen(navController, viewModel) }
+        composable("home") { MainScreen(navController,viewModel) }
     }
 }

--- a/app/src/main/java/com/dining/totable/ui/screens/LoginScreen.kt
+++ b/app/src/main/java/com/dining/totable/ui/screens/LoginScreen.kt
@@ -3,15 +3,21 @@ package com.dining.totable.ui.screens
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -20,6 +26,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.dining.totable.R
 import com.dining.totable.ui.composables.buttons.ToTableButton
@@ -28,10 +35,20 @@ import com.dining.totable.ui.composables.textfields.ToTableTextField
 import com.dining.totable.utils.DeviceConfigManager
 import com.dining.totable.utils.DeviceConfiguration
 import com.dining.totable.utils.DeviceRole
+import com.dining.totable.viewmodels.ToTableViewModel
 import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 
 @Composable
-fun LoginScreen(navController: NavController) {
+fun LoginScreen(
+    navController: NavController,
+    viewModel: ToTableViewModel
+) {
+    val coroutineScope = rememberCoroutineScope()
+    val context = LocalContext.current
+    var isLoading by remember { mutableStateOf(false) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
     var restaurantEmail by remember { mutableStateOf("") }
     var restaurantPassword by remember { mutableStateOf("") }
     var role: DeviceRole? by remember { mutableStateOf(null) }
@@ -68,33 +85,53 @@ fun LoginScreen(navController: NavController) {
             ),
             isError = false
         )
+        if (isLoading) {
+            Box(
+                modifier = Modifier
+                    .padding(vertical = 16.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(32.dp),
+                    color = MaterialTheme.colorScheme.primary,
+                    strokeWidth = 4.dp
+                )
+            }
+        }
         RoleDropdown(selectedRole = role, onRoleSelected = { selectedRole ->
             role = selectedRole
         })
-        val context = LocalContext.current
         ToTableButton(stringResource(R.string.login)) {
             if (role != null) { // ensure they select a role before attempting login
-                login(
-                    restaurantEmail = restaurantEmail,
-                    restaurantPassword = restaurantPassword,
-                    onLoginAttemptFailed = {
-                        Log.w(TAG, "$it ?: ${context.getString(R.string.login_failed)}")
-                        Toast.makeText(
-                            context,
-                            context.getString(R.string.login_failed),
-                            Toast.LENGTH_SHORT,
-                        ).show()
-                    },
-                    onLoginAttemptSuccess = {
-                        DeviceConfigManager(context).saveConfiguration(
-                            DeviceConfiguration(
-                                deviceRole = role!!, // save the role so device starts in correct role next time
-                                restaurantId = restaurantEmail
+                coroutineScope.launch {
+                    isLoading = true
+                    errorMessage = null
+                    login(
+                        restaurantEmail = restaurantEmail,
+                        restaurantPassword = restaurantPassword,
+                        viewModel = viewModel,
+                        onLoginAttemptFailed = {
+                            Log.w(TAG, "$it ?: ${context.getString(R.string.login_failed)}")
+                            Toast.makeText(
+                                context,
+                                context.getString(R.string.login_failed),
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                            isLoading = false
+                        },
+                        onLoginAttemptSuccess = { restaurantId ->
+                            DeviceConfigManager(context).saveConfiguration(
+                                DeviceConfiguration(
+                                    deviceRole = role!!, // save the role so device starts in correct role next time
+                                    restaurantEmail = restaurantEmail,
+                                    restaurantId = restaurantId
+                                )
                             )
-                        )
-                        navController.navigate("home")
-                    }
-                )
+                            navController.navigate("home")
+                            isLoading = false
+                        }
+                    )
+                }
             } else {
                 Toast.makeText(
                     context,
@@ -106,21 +143,27 @@ fun LoginScreen(navController: NavController) {
     }
 }
 
-private fun login(
+private suspend fun login(
     restaurantEmail: String,
     restaurantPassword: String,
+    viewModel: ToTableViewModel,
     onLoginAttemptFailed: (String?) -> Unit,
-    onLoginAttemptSuccess: () -> Unit
+    onLoginAttemptSuccess: (String) -> Unit
 ) {
-    FirebaseAuth.getInstance()
-        .signInWithEmailAndPassword(restaurantEmail, restaurantPassword)
-        .addOnCompleteListener { task ->
-            if (task.isSuccessful) {
-                onLoginAttemptSuccess()
-            } else {
-                onLoginAttemptFailed(task.exception?.localizedMessage)
-            }
+    try {
+        FirebaseAuth.getInstance()
+            .signInWithEmailAndPassword(restaurantEmail, restaurantPassword)
+            .await()
+        val restaurantId = viewModel.fetchRestaurantIdByEmail(restaurantEmail)
+        if (restaurantId != null) {
+            onLoginAttemptSuccess(restaurantId)
+        } else {
+            FirebaseAuth.getInstance().signOut()
+            onLoginAttemptFailed("No restaurant found for this email")
         }
+    } catch (e: Exception) {
+        onLoginAttemptFailed(e.localizedMessage)
+    }
 }
 
 const val TAG = "LoginScreen"

--- a/app/src/main/java/com/dining/totable/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/dining/totable/ui/screens/MainScreen.kt
@@ -13,19 +13,20 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.dining.totable.ui.composables.MainScreenTopBar
 import com.dining.totable.ui.composables.OrderItem
 import com.dining.totable.ui.utils.TopBarOption
 import com.dining.totable.utils.DeviceConfigManager
-import com.dining.totable.viewmodels.OrdersViewModel
+import com.dining.totable.viewmodels.ToTableViewModel
 
 @Composable
-fun MainScreen(navController: NavController) {
+fun MainScreen(
+    navController: NavController,
+    viewModel: ToTableViewModel
+) {
     val activity = LocalActivity.current
     val context = LocalContext.current
-    val viewModel: OrdersViewModel = viewModel()
     val orders by viewModel.orders.observeAsState()
     DisposableEffect(Unit) {
         // Force landscape when entering the screen
@@ -36,7 +37,7 @@ fun MainScreen(navController: NavController) {
         }
     }
     LaunchedEffect(Unit) {
-        viewModel.fetchOrders("XvVycxpXfZeerplOtH7b5mKVvSl1")
+        viewModel.fetchOrders(DeviceConfigManager(context).getConfiguration()!!.restaurantId)
     }
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -52,7 +53,8 @@ fun MainScreen(navController: NavController) {
                 }
             )
         }) { paddingValues ->
-        LazyColumn(modifier = Modifier.fillMaxSize(),
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
             contentPadding = paddingValues
         ) {
             orders?.let { orderList ->

--- a/app/src/main/java/com/dining/totable/utils/DeviceConfigManager.kt
+++ b/app/src/main/java/com/dining/totable/utils/DeviceConfigManager.kt
@@ -8,6 +8,7 @@ import com.google.gson.Gson
 
 data class DeviceConfiguration(
     val deviceRole: DeviceRole,
+    val restaurantEmail: String,
     val restaurantId: String
 )
 


### PR DESCRIPTION
### Summary
This PR addresses issue #14  by removing the hardcoded `restaurantId` in the Android app and implementing dynamic fetching of the `restaurantId` using the account email during login. The `LoginScreen` now authenticates users via Firebase Authentication, queries the `restaurants` collection to retrieve the `restaurantId` based on the email, and saves it in `DeviceConfiguration` for use in fetching restaurant orders.

### Changes Made
- **Dynamic `restaurantId` Fetching**:
  - Updated `LoginScreen` to call a `suspend` `login` function within a coroutine, passing the user’s email to fetch the `restaurantId`.
  - Modified the `login` function to:
    - Use `FirebaseAuth.getInstance().signInWithEmailAndPassword().await()` for asynchronous authentication, verifying email and password.
    - Call `viewModel.fetchRestaurantIdByEmail(restaurantEmail)` to query the `restaurants` collection and retrieve the `restaurantId` based on the email.
    - Save the `restaurantId`, `restaurantEmail`, and `deviceRole` in `DeviceConfiguration` on successful login.
    - Sign out and trigger `onLoginAttemptFailed` if no restaurant is found for the email.
  - Ensured password verification remains intact via Firebase Authentication, handling errors (e.g., invalid password) with `try-catch`.

### Rationale
- Hardcoded `restaurantId`s are unsustainable and limit the app to a single restaurant, as noted in issue #14.
- Fetching the `restaurantId` by email aligns with the web app’s authentication flow and enables dynamic order fetching for any restaurant.

### Related Issues
- #14: Dynamically fetch restaurant ID