### PR TITLE
Allow Android to update order statuses

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,4 +90,7 @@ dependencies {
     implementation("com.google.firebase:firebase-auth")
 
     implementation ("androidx.compose.runtime:runtime-livedata:1.7.8")
+
+    // Swipe to Dismiss
+    implementation ("androidx.compose.material:material:1.8.0")
 }

--- a/app/src/main/java/com/dining/totable/ui/composables/OrderItem.kt
+++ b/app/src/main/java/com/dining/totable/ui/composables/OrderItem.kt
@@ -1,80 +1,128 @@
 package com.dining.totable.ui.composables
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Text
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.dining.totable.ui.utils.SpecialRequests
+import androidx.compose.ui.unit.sp
 import com.dining.totable.viewmodels.Order
 
 @Composable
 fun OrderItem(
     item: Order.Item,
-    hasTellMe: Boolean? = false
+    orderStatus: String,
+    hasTellMe: Boolean? = false,
+    onClick: () -> Unit
 ) {
+    val isInProgress = orderStatus == "in-progress"
+    val backgroundColor = if (isInProgress) {
+        Brush.linearGradient(
+            colors = listOf(Color(0xFFFFCA28), Color(0xFFFFA000)),
+            start = androidx.compose.ui.geometry.Offset(0f, 0f),
+            end = androidx.compose.ui.geometry.Offset(1000f, 1000f)
+        )
+    } else {
+        Brush.linearGradient(
+            colors = listOf(Color.White, Color(0xFFF5F5F5))
+        )
+    }
+    val elevation = if (isInProgress) CardDefaults.cardElevation(defaultElevation = 12.dp) else CardDefaults.cardElevation(defaultElevation = 4.dp)
+    val textColor = if (isInProgress) Color.White else Color.Black
+    val statusBadgeColor = if (isInProgress) Color(0xFF0277BD) else Color(0xFF757575)
+
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(4.dp),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
-        border = BorderStroke(
-            width = Dp.Hairline,
-            color = Color.Black
-        )
+            .padding(horizontal = 8.dp, vertical = 4.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .shadow(8.dp, RoundedCornerShape(16.dp))
+            .clickable { onClick() },
+        elevation = elevation,
+        colors = CardDefaults.cardColors(containerColor = Color.Transparent),
+        border = BorderStroke(width = 1.dp, color = Color(0xFFE0E0E0))
     ) {
-        Column(modifier = Modifier
-            .fillMaxWidth()
-            .padding(4.dp)) {
-            ItemNameText(
-                itemName = "${item.itemName} (x${item.quantity})",
-                modifier = Modifier.padding(bottom = 4.dp)
-            )
-            if (item.specialRequests.isNotEmpty()) {
-                OrderItemSpecialRequestCard(containerColor = Color.Gray) {
-                    SpecialRequestText(
-                        specialRequest = item.specialRequests,
-                        specialRequestColor = Color.Unspecified
+        Box(
+            modifier = Modifier
+                .background(backgroundColor)
+                .padding(16.dp)
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(
+                        text = "${item.itemName} (x${item.quantity})",
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 18.sp,
+                        color = textColor,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
                     )
+                    Surface(
+                        modifier = Modifier
+                            .padding(top = 4.dp)
+                            .wrapContentSize(),
+                        shape = RoundedCornerShape(12.dp),
+                        color = statusBadgeColor,
+                        contentColor = Color.White
+                    ) {
+                        Text(
+                            text = orderStatus.replaceFirstChar { it.uppercase() },
+                            fontWeight = FontWeight.Medium,
+                            fontSize = 12.sp,
+                            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
+                        )
+                    }
+                    if (item.specialRequests.isNotEmpty()) {
+                        OrderItemSpecialRequestCard(
+                            containerColor = Color(0x33FFFFFF),
+                            modifier = Modifier.padding(top = 8.dp)
+                        ) {
+                            SpecialRequestText(
+                                specialRequest = item.specialRequests,
+                                specialRequestColor = textColor
+                            )
+                        }
+                    }
+                    if (hasTellMe == true) {
+                        OrderItemSpecialRequestCard(
+                            containerColor = Color(0xFF0288D1),
+                            modifier = Modifier.padding(top = 4.dp)
+                        ) {
+                            SpecialRequestText(
+                                specialRequest = "Tell Me!",
+                                specialRequestColor = Color.White
+                            )
+                        }
+                    }
                 }
+                Text(
+                    text = "€${String.format("%.2f", item.price * item.quantity)}",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 16.sp,
+                    color = textColor,
+                    modifier = Modifier.align(Alignment.CenterVertically)
+                )
             }
-            if (hasTellMe == true) {
-                OrderItemSpecialRequestCard(containerColor = Color.Blue) {
-                    SpecialRequestText(
-                        specialRequest = "Tell Me!",
-                        specialRequestColor = Color.White
-                    )
-                }
-            }
-            ItemNameText(
-                itemName = "€${item.price * item.quantity}",
-                modifier = Modifier.align(Alignment.End)
-            )
         }
     }
-}
-
-@Composable
-private fun ItemNameText(
-    itemName: String,
-    modifier: Modifier = Modifier
-) {
-    Text(
-        text = itemName,
-        fontWeight = FontWeight.Bold,
-        modifier = modifier
-    )
 }
 
 @Composable
@@ -84,16 +132,16 @@ private fun OrderItemSpecialRequestCard(
     content: @Composable () -> Unit
 ) {
     Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .padding(4.dp),
         colors = CardDefaults.cardColors(containerColor = containerColor),
-        border = BorderStroke(
-            width = Dp.Hairline,
-            color = Color.Black
-        ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 4.dp),
-        modifier = modifier.padding(bottom = 2.dp)
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        border = BorderStroke(width = 0.5.dp, color = Color(0xFFB0BEC5))
     ) {
         Box(
-            modifier = Modifier.padding(4.dp)
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp)
         ) {
             content()
         }
@@ -108,14 +156,14 @@ private fun SpecialRequestText(
     Text(
         text = specialRequest,
         color = specialRequestColor,
-        fontWeight = FontWeight.Bold,
+        fontWeight = FontWeight.Medium,
+        fontSize = 14.sp,
+        maxLines = 2,
+        overflow = TextOverflow.Ellipsis
     )
 }
 
-@Preview(
-    showBackground = true,
-    showSystemUi = true
-)
+@Preview(showBackground = true, showSystemUi = true)
 @Composable
 fun OrderItemPreview() {
     OrderItem(
@@ -125,6 +173,24 @@ fun OrderItemPreview() {
             quantity = 2,
             specialRequests = "No pickles, extra lettuce"
         ),
-        hasTellMe = true
+        orderStatus = "in-progress",
+        hasTellMe = true,
+        onClick = {}
+    )
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun OrderItemPendingPreview() {
+    OrderItem(
+        item = Order.Item(
+            itemName = "Cheeseburger",
+            price = 8.99,
+            quantity = 2,
+            specialRequests = "No pickles, extra lettuce"
+        ),
+        orderStatus = "pending",
+        hasTellMe = false,
+        onClick = {}
     )
 }


### PR DESCRIPTION
Updated the main page to include tappable order items (to mark them as in-progress) and swipe them (to mark them as complete). Closes #20 